### PR TITLE
Finalizer. ISSUES: creator does not finalize, and shows incorrect seconds since creation

### DIFF
--- a/include/finalizer.h
+++ b/include/finalizer.h
@@ -1,8 +1,49 @@
 #ifndef PROYECTO1_FINALIZER_H
 #define PROYECTO1_FINALIZER_H
 
-//Finalizer dummy stuff
-char msg[10];
-int print_msg();
+#include <sys/time.h>
+#include "utils.h"
+
+// Structs
+
+/**
+ * Producer structure
+ */
+typedef struct finalizer_t
+{
+    /** Process ID */
+    unsigned int process_id;
+
+    /** Buffer file name */
+    char *buffer_name;
+
+    /** Produced messages counter */
+    unsigned int message_count;
+
+    /** Blocked time by cbuffer empty space semaphore in seconds */
+    struct timeval blocked_time_by_empty_sem_s;
+
+    /** Blocked time by cbuffer write mutex in seconds */
+    struct timeval blocked_time_by_wr_mut_s;
+
+    /** Waiting time for producers in seconds */
+    struct timeval waiting_producers;
+
+    /** Waiting time for consumers in seconds */
+    struct timeval waiting_consumers;
+
+    /** Whole time for finalizer to run in seconds */
+    struct timeval time_elapsed;
+
+    /** System shared state **/
+    system_sh_state_t *sys_state;
+
+    /** Shared circular buffer */
+    circular_buffer_t *cbuffer;
+} finalizer_t;
+
+int new_finalizer(finalizer_t *finalizer, char* buffer_name);
+
+int run_finalizer(finalizer_t *finalizer);
 
 #endif //PROYECTO1_FINALIZER_H

--- a/include/finalizer.h
+++ b/include/finalizer.h
@@ -7,7 +7,7 @@
 // Structs
 
 /**
- * Producer structure
+ * Finalizer structure
  */
 typedef struct finalizer_t
 {
@@ -42,8 +42,21 @@ typedef struct finalizer_t
     circular_buffer_t *cbuffer;
 } finalizer_t;
 
+/**
+ * Initialize new finalizer
+ *
+ * @param finalizer
+ * @param buffer_name
+ * @return
+ */
 int new_finalizer(finalizer_t *finalizer, char* buffer_name);
 
+/**
+ * Run finalizer
+ *
+ * @param finalizer
+ * @return
+ */
 int run_finalizer(finalizer_t *finalizer);
 
 #endif //PROYECTO1_FINALIZER_H

--- a/src/consumer.c
+++ b/src/consumer.c
@@ -188,6 +188,11 @@ int run_consumer(consumer_t *consumer)
             break;
         }
 
+        if (message.consumer_key == -1){
+            printf("Finalize message recieved.\n");
+            break;
+        }
+
         system_alive = consumer->sys_state->keep_alive;
 
     }

--- a/src/finalizer.c
+++ b/src/finalizer.c
@@ -3,9 +3,280 @@
 #include "finalizer.h"
 #include "buffer.h"
 
-int print_msg()
-{
-    strcpy(msg, "Finalizer");
-    printf("loaded >>> %s %i \n", msg, get_buffer_int());
-    return 0;
+int new_finalizer(finalizer_t *finalizer, char *buffer_name){
+    finalizer->process_id = getpid();
+    finalizer->buffer_name = buffer_name;
+    finalizer->message_count = 0;
+    finalizer->blocked_time_by_empty_sem_s = (struct timeval){0};
+    finalizer->blocked_time_by_wr_mut_s = (struct timeval){0};
+
+    finalizer->sys_state = shm_system_state_get(buffer_name);
+    if (!finalizer->sys_state) return EXIT_FAILURE;
+
+    finalizer->cbuffer = shm_cbuffer_get(buffer_name,
+                                        finalizer->sys_state->buffer_size,
+                                        finalizer->sys_state->cbuffer_address);
+    if (!finalizer->cbuffer) return EXIT_FAILURE;
+
+    return EXIT_SUCCESS;
+}
+
+int run_finalizer(finalizer_t *finalizer){
+
+    //Start finishing producers ASAP
+    finalizer->sys_state->keep_alive = false;
+
+    int ret;
+    message_t message;
+    struct timeval start_time, end_time, time_interval, start_p_c, end_p_c, start_all, end_all;
+    unsigned int time_elapsed, cbuffer_index, waiting_c, waiting_p;
+    unsigned int producer_count, consumer_count;
+
+
+    // Get current time
+    ret = gettimeofday(&start_all, NULL);
+    if (ret) {
+        fprintf(stderr,
+                "\nFinalizer PID: %u for buffer: %s failed to get current time\n",
+                finalizer->process_id,
+                finalizer->buffer_name);
+        return ret;
+    }
+
+    // Get producers and consumers count
+    producer_count = finalizer->sys_state->producer_count;
+    consumer_count = finalizer->sys_state->consumer_count;
+
+    // Get current time
+    ret = gettimeofday(&start_p_c, NULL);
+    if (ret) {
+        fprintf(stderr,
+                "\nFinalizer PID: %u for buffer: %s failed to get current time\n",
+                finalizer->process_id,
+                finalizer->buffer_name);
+        return ret;
+    }
+
+    //Will send finalize messages until consumers are all terminated.
+    while(consumer_count>0){
+        // Get current time
+        message.time_of_creation = time(NULL);
+
+        // Get consumer key -1 for finalization
+        message.consumer_key = -1;
+
+        // Get current time
+        ret = gettimeofday(&start_time, NULL);
+        if (ret) {
+            fprintf(stderr,
+                    "\nFinalizer PID: %u for buffer: %s failed to get current time\n",
+                    finalizer->process_id,
+                    finalizer->buffer_name);
+            return ret;
+        }
+
+        // Lock empty semaphore
+        ret = sem_wait(&finalizer->sys_state->sem_cbuffer_empty);
+        if (ret) {
+            fprintf(stderr,
+                    "\nFinalizer PID: %u for buffer: %s failed to lock empty space\n",
+                    finalizer->process_id,
+                    finalizer->buffer_name);
+            return ret;
+        }
+
+        // Get current time
+        ret = gettimeofday(&end_time, NULL);
+        if (ret) {
+            fprintf(stderr,
+                    "\nFinalizer PID: %u for buffer: %s failed to get current time\n",
+                    finalizer->process_id,
+                    finalizer->buffer_name);
+            return ret;
+        }
+
+        // Compute blocked time by cbuffer empty space semaphore
+        time_interval = get_time_interval(start_time, end_time);
+        finalizer->blocked_time_by_empty_sem_s.tv_sec += time_interval.tv_sec;
+        finalizer->blocked_time_by_empty_sem_s.tv_usec += time_interval.tv_usec;
+
+        // Get current time
+        ret = gettimeofday(&start_time, NULL);
+        if (ret) {
+            fprintf(stderr,
+                    "\nFinalizer PID: %u for buffer: %s failed to get current time\n",
+                    finalizer->process_id,
+                    finalizer->buffer_name);
+            return ret;
+        }
+
+        // Lock cbuffer write mutex
+        ret = sem_wait(&finalizer->sys_state->mut_cbuffer_write);
+        if (ret) {
+            fprintf(stderr,
+                    "\nFinalizer PID: %u for buffer: %s failed to lock cbuffer write\n",
+                    finalizer->process_id,
+                    finalizer->buffer_name);
+            return ret;
+        }
+
+        // Get current time
+        ret = gettimeofday(&end_time, NULL);
+        if (ret) {
+            fprintf(stderr,
+                    "\nFinalizer PID: %u for buffer: %s failed to get current time\n",
+                    finalizer->process_id,
+                    finalizer->buffer_name);
+            return ret;
+        }
+
+        // Compute blocked time by cbuffer write mutex
+        time_interval = get_time_interval(start_time, end_time);
+        finalizer->blocked_time_by_wr_mut_s.tv_sec += time_interval.tv_sec;
+        finalizer->blocked_time_by_wr_mut_s.tv_usec += time_interval.tv_usec;
+
+        // Write message into shared buffer
+        cbuffer_index = circular_buffer_put(finalizer->cbuffer, message);
+        if (cbuffer_index < 0) {
+            fprintf(stderr,
+                    "\nFinalizer PID: %u for buffer: %s failed to write into buffer\n",
+                    finalizer->process_id,
+                    finalizer->buffer_name);
+            ret = EXIT_FAILURE;
+            return ret;
+        }
+
+        // Unlock cbuffer write mutex
+        ret = sem_post(&finalizer->sys_state->mut_cbuffer_write);
+        if (ret) {
+            fprintf(stderr,
+                    "\nFinalizer PID: %u for buffer: %s failed to unlock cbuffer write\n",
+                    finalizer->process_id,
+                    finalizer->buffer_name);
+            return ret;
+        }
+
+        // Post message semaphore
+        ret = sem_post(&finalizer->sys_state->sem_cbuffer_message);
+        if (ret) {
+            fprintf(stderr,
+                    "\nFinalizer PID: %u for buffer: %s failed to post message semaphore\n",
+                    finalizer->process_id,
+                    finalizer->buffer_name);
+            return ret;
+        }
+
+        // Get producers and consumers count
+        producer_count = finalizer->sys_state->producer_count;
+        consumer_count = finalizer->sys_state->consumer_count;
+
+
+        // Increment produced messages count
+        finalizer->message_count += 1;
+
+
+        // Print message
+        fprintf(stdout, "\nBuffer: %s was written at index %u by finalizer\n"
+                " Producers counter %u, Consumers counter %u\n",
+                finalizer->buffer_name, cbuffer_index, producer_count,
+                consumer_count);
+        message_print(message);
+    }
+
+    // Get current time
+    ret = gettimeofday(&end_p_c, NULL);
+    if (ret) {
+        fprintf(stderr,
+                "\nFinalizer PID: %u for buffer: %s failed to get current time\n",
+                finalizer->process_id,
+                finalizer->buffer_name);
+        return ret;
+    }
+    
+    // Compute time waiting for consumers
+    time_interval = get_time_interval(start_p_c, end_p_c);
+    finalizer->waiting_consumers.tv_sec = time_interval.tv_sec;
+    finalizer->waiting_consumers.tv_usec = time_interval.tv_usec;
+
+    // Get current time
+    ret = gettimeofday(&start_p_c, NULL);
+    if (ret) {
+        fprintf(stderr,
+                "\nFinalizer PID: %u for buffer: %s failed to get current time\n",
+                finalizer->process_id,
+                finalizer->buffer_name);
+        return ret;
+    }
+
+    //Will wait for producers before unmapping
+    while(producer_count > 0){
+        //signal producers????
+        producer_count = finalizer->sys_state->producer_count;
+    }
+
+    // Get current time
+    ret = gettimeofday(&end_p_c, NULL);
+    if (ret) {
+        fprintf(stderr,
+                "\nFinalizer PID: %u for buffer: %s failed to get current time\n",
+                finalizer->process_id,
+                finalizer->buffer_name);
+        return ret;
+    }
+
+    // Compute time waiting for producers
+    time_interval = get_time_interval(start_p_c, end_p_c);
+    finalizer->waiting_producers.tv_sec = time_interval.tv_sec;
+    finalizer->waiting_producers.tv_usec = time_interval.tv_usec;
+
+
+    //Unmap buffer
+    finalizer->cbuffer = cbuffer_unmap_close(finalizer->cbuffer, finalizer->buffer_name);
+
+    //Unmap system state
+    finalizer->sys_state = sys_state_unmap_close(finalizer->sys_state, finalizer->buffer_name);
+    if (!finalizer->sys_state) {
+        exit(EXIT_FAILURE);
+    }
+
+    // Get current time
+    ret = gettimeofday(&end_all, NULL);
+    if (ret) {
+        fprintf(stderr,
+                "\nFinalizer PID: %u for buffer: %s failed to get current time\n",
+                finalizer->process_id,
+                finalizer->buffer_name);
+        return ret;
+    }
+
+    // Compute whole time
+    time_interval = get_time_interval(start_all, end_all);
+    finalizer->time_elapsed.tv_sec = time_interval.tv_sec;
+    finalizer->time_elapsed.tv_usec = time_interval.tv_usec;
+    
+
+    //TODO STATS
+    fprintf(stdout,
+            "\n Finalizer PID: %u for buffer: %s has finalized {\n",
+            finalizer->process_id, finalizer->buffer_name);
+    fprintf(stdout," Producers counter %u\n", producer_count);
+    fprintf(stdout,
+            " Finalizer messages counter: %u\n", finalizer->message_count);
+    fprintf(stdout,
+            " Finalizer accumulated blocked time by cbuffer empty space semaphore: %lu seconds and %lu milliseconds\n",
+            finalizer->blocked_time_by_empty_sem_s.tv_sec, finalizer->blocked_time_by_empty_sem_s.tv_usec);
+    finalizer->blocked_time_by_wr_mut_s = format_accumulated_time(finalizer->blocked_time_by_wr_mut_s);
+    fprintf(stdout,
+            " Finalizer accumulated blocked time by cbuffer write mutex: %lu seconds and %lu milliseconds\n",
+           finalizer->blocked_time_by_wr_mut_s.tv_sec, finalizer->blocked_time_by_wr_mut_s.tv_usec);
+    fprintf(stdout,
+            " Finalizer total consumer waiting time: %lu seconds and %lu milliseconds\n",
+           finalizer->waiting_consumers.tv_sec, finalizer->waiting_consumers.tv_usec);
+    fprintf(stdout,
+            " Finalizer total producer waiting time: %lu seconds and %lu milliseconds\n",
+           finalizer->waiting_producers.tv_sec, finalizer->waiting_producers.tv_usec);
+    fprintf(stdout,
+            " Finalizer total running time: %lu seconds and %lu milliseconds\n",
+           finalizer->time_elapsed.tv_sec, finalizer->time_elapsed.tv_usec);
+    fprintf(stdout, "}\n");
 }

--- a/src/finalizer.c
+++ b/src/finalizer.c
@@ -59,6 +59,11 @@ int run_finalizer(finalizer_t *finalizer){
         return ret;
     }
 
+
+    fprintf(stderr, "Initializing finalizer\n");
+
+
+    fprintf(stderr, "Consumer count %i\n", consumer_count);
     //Will send finalize messages until consumers are all terminated.
     while(consumer_count>0){
         // Get current time
@@ -211,6 +216,8 @@ int run_finalizer(finalizer_t *finalizer){
     }
 
     //Will wait for producers before unmapping
+
+    fprintf(stderr, "Producer count %i\n", producer_count);
     while(producer_count > 0){
         //signal producers????
         producer_count = finalizer->sys_state->producer_count;

--- a/src/finalizer_main.c
+++ b/src/finalizer_main.c
@@ -30,11 +30,17 @@ int main(int argc, char *argv[]) {
       exit(EXIT_FAILURE);
   }
 
+
+  fprintf(stderr, "Initializing finalizer\n");
+
   status = new_finalizer(&finalizer, buffer_name);
   if(status){
     fprintf(stderr, "Error while creating finalizer\n");
     return status;
   }
+
+
+  fprintf(stderr, "Running finalizer\n");
 
   status = run_finalizer(&finalizer);
     if (status){

--- a/src/finalizer_main.c
+++ b/src/finalizer_main.c
@@ -7,8 +7,9 @@
 
 int main(int argc, char *argv[]) {
   int opt;
+  int status;
   char * buffer_name = NULL;
-  system_sh_state_t *system_state;
+  finalizer_t finalizer;
 
   // Get buffer name
   while ((opt = getopt(argc, argv, "b:")) != -1) {
@@ -29,12 +30,17 @@ int main(int argc, char *argv[]) {
       exit(EXIT_FAILURE);
   }
 
-  system_state = shm_system_state_get(buffer_name);
-  if (!system_state) {
-    exit(EXIT_FAILURE);
+  status = new_finalizer(&finalizer, buffer_name);
+  if(status){
+    fprintf(stderr, "Error while creating finalizer\n");
+    return status;
   }
 
-  system_state->keep_alive = false;
-
+  status = run_finalizer(&finalizer);
+    if (status){
+        fprintf(stderr, "Error while running finalizer\n");
+        return status;
+  }
+  
   exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
Para ayudar a los producers que se quedan pegados hago signaling a pata para que puedan continuar. Los producers se finalizan correctamente y los consumers también. El creator no se finaliza y muestra segundos incorrectos desde el momento de creación.

DISCUSIÓN: 
1. el finalizer manda mensajes para terminar los consumidores hasta que ya no hayan consumidores, sin esperar. Mucho spam de mensajes?

2. El finalizer hace signals para producers hasta que ya no hayan producers. Muchos signals??